### PR TITLE
feat: install Claude Code agent skills & plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ DOTFILES_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 export XDG_CONFIG_HOME = $(HOME)/.config
 
 install: install-minimal install-extra
-install-minimal: sudo core packages docker-compose link quartz-filters plannotator
+install-minimal: sudo core packages docker-compose link quartz-filters plannotator claude-skills
 install-extra: brew-packages-extra cask-apps-extra
 
 sudo:
@@ -107,6 +107,41 @@ quartz-filters:
 # the claude-code cask exists for the installer's agent integration.
 plannotator:
 	curl -fsSL https://plannotator.ai/install.sh | bash -s -- --non-interactive
+
+#
+# CLAUDE CODE SKILLS & PLUGINS
+#
+# Agent skills/plugins aren't dotfiles to track — they're generated artifacts
+# (like plannotator's skills), so we (re)install them from source instead of
+# vendoring them. Everything lands under ~/.claude (or $CLAUDE_CONFIG_DIR).
+# Grouped after `packages` so the `claude` CLI (claude-code cask) and node exist.
+CLAUDE_SKILLS_DIR := $(if $(CLAUDE_CONFIG_DIR),$(CLAUDE_CONFIG_DIR),$(HOME)/.claude)/skills
+
+claude-skills: superpowers mcollina-skills playwright-skills
+
+# obra/superpowers is a real Claude Code plugin (hooks, /brainstorm, SessionStart
+# injection), so it goes through the plugin CLI rather than being copied as loose
+# skills. `marketplace add` is made idempotent so re-runs don't fail; the first
+# install may prompt once to trust the marketplace — answer it interactively.
+superpowers:
+	claude plugin marketplace add obra/superpowers-marketplace || true
+	claude plugin install superpowers@superpowers-marketplace --scope user
+
+# mcollina/skills is a plain skills folder (dirs with SKILL.md, no plugin
+# manifest), so the plugin CLI can't consume it — shallow-clone and copy the
+# skills into place. Re-running refreshes them to the latest commit.
+mcollina-skills:
+	mkdir -p "$(CLAUDE_SKILLS_DIR)"
+	tmp=$$(mktemp -d) && \
+		git clone --depth 1 https://github.com/mcollina/skills "$$tmp" && \
+		cp -R "$$tmp"/skills/. "$(CLAUDE_SKILLS_DIR)/" && \
+		rm -rf "$$tmp"
+
+# @playwright/cli installs its own Claude Code skill via `install --skills`
+# (lands in ~/.claude/skills/playwright-cli).
+playwright-skills:
+	npm install -g @playwright/cli@latest
+	playwright-cli install --skills
 
 # Stow test commands:
 # stow --adopt -nvSt ~ runcom

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Initially forked from https://github.com/webpro/dotfiles. It targets only macOS 
 - [homebrew-cask](https://caskroom.github.io) (packages: [Caskfile](./install/Caskfile))
 - [Node.js + npm LTS](https://nodejs.org/en/download/)
 - [Plannotator](https://plannotator.ai) (not on Homebrew — installed via its official script by `make`; see [below](#plannotator))
+- Claude Code agent skills & plugins ([superpowers](https://github.com/obra/superpowers), [mcollina/skills](https://github.com/mcollina/skills), [@playwright/cli](https://playwright.dev/docs/getting-started-cli); see [below](#claude-code-skills--plugins))
 - Latest Git, ZSH, GNU coreutils, curl
 
 ## Install
@@ -63,6 +64,20 @@ To add another app: create `install/<app-name>/`, commit its exported configurat
 - integrates with coding agents it detects, which is why it runs after `packages` (so the `claude-code` cask already exists).
 
 Both the binary and the skills are generated artifacts (like a `git` checkout), so nothing here is tracked in this repo. To change the extras / model-invocable choices skipped by `--non-interactive`, run `plannotator --reconfigure` by hand.
+
+## Claude Code skills & plugins
+
+`make` installs a few [Claude Code](https://claude.com/claude-code) agent add-ons under `~/.claude` (or `$CLAUDE_CONFIG_DIR`) via the [`claude-skills` Makefile target](./Makefile). Like plannotator's skills, these are generated artifacts installed from source, so nothing is tracked in this repo:
+
+| Add-on                                                             | Kind                                                                 | How it's installed                                                                 |
+| ------------------------------------------------------------------ | -------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| [superpowers](https://github.com/obra/superpowers)                 | Claude Code **plugin** (hooks, `/brainstorm`, session-start context) | `claude plugin marketplace add` + `claude plugin install @superpowers-marketplace` |
+| [mcollina/skills](https://github.com/mcollina/skills)              | Plain skills (no plugin manifest)                                    | shallow `git clone`, copied into `~/.claude/skills/`                               |
+| [@playwright/cli](https://playwright.dev/docs/getting-started-cli) | npm CLI + its own skill                                              | `npm i -g @playwright/cli@latest` + `playwright-cli install --skills`              |
+
+Runs after `packages` so the `claude` CLI and Node are available. The superpowers step may prompt once to trust its marketplace — answer it interactively. Re-running the target refreshes each add-on to its latest version.
+
+An alternative to the imperative `superpowers` target would be to declare the marketplace + plugin in a global `~/.claude/settings.json` (`extraKnownMarketplaces` + `enabledPlugins`) and let Claude Code auto-install on startup — but this repo doesn't manage `~/.claude`, so the Makefile route is used instead.
 
 ## Post-install
 


### PR DESCRIPTION
Add a `claude-skills` Makefile target (wired into install-minimal after `packages`, so the `claude` CLI and node exist) that installs three agent add-ons under ~/.claude, none tracked in the repo since they're generated from source:

- superpowers: a real Claude Code plugin, via `claude plugin marketplace add obra/superpowers-marketplace` + `claude plugin install`.
- mcollina/skills: plain skills (no plugin manifest), shallow-cloned and copied into ~/.claude/skills.
- @playwright/cli: npm global + `playwright-cli install --skills`.